### PR TITLE
[bug-fix] missing python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 python-ldap
+ldap3
+impacket


### PR DESCRIPTION
I know most people have it installed globally but `ldap3` and `impacket` are missing from the `requirements.txt` to run the tool ;)