### PR TITLE
Add interactive export command (#15)

### DIFF
--- a/ldapconsole.py
+++ b/ldapconsole.py
@@ -5,6 +5,9 @@
 # Date created       : 29 Jul 2021
 
 import argparse
+import csv
+import datetime
+import json
 from ldap3.protocol.formatters.formatters import format_sid
 import ldap3
 import os
@@ -30,8 +33,15 @@ class CommandCompleter(object):
                 "subcommands": []
             },
             "exit": {
-                "description": ["Exits the ldapconsole script."], 
+                "description": ["Exits the ldapconsole script."],
                 "subcommands": []
+            },
+            "export": {
+                "description": [
+                    "Export the results of the last query to a file.",
+                    "Syntax: export <json|csv|xlsx> <path>"
+                ],
+                "subcommands": ["json", "csv", "xlsx"]
             },
             "help": {
                 "description": ["Displays this help message."], 
@@ -143,6 +153,128 @@ def dict_path_access(d, path):
         else:
             return None
     return d
+
+
+### Export helpers
+
+EXPORT_FORMATS = ("json", "csv", "xlsx")
+
+
+def _resolve_export_path(path):
+    basepath = os.path.dirname(path)
+    filename = os.path.basename(path)
+    if basepath not in [".", ""]:
+        if not os.path.exists(basepath):
+            os.makedirs(basepath)
+        return basepath + os.path.sep + filename
+    return filename
+
+
+def _collect_attributes(results, requested_attributes):
+    if requested_attributes and "*" not in requested_attributes:
+        return list(requested_attributes)
+    attributes = set()
+    for dn in results.keys():
+        attributes.update(results[dn].keys())
+    return sorted(attributes)
+
+
+def _stringify_cell(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.hex()
+    if isinstance(value, list):
+        return "\n".join(_stringify_cell(v) for v in value)
+    if isinstance(value, ldap3.utils.ciDict.CaseInsensitiveDict):
+        return json.dumps({k: _jsonable(v) for k, v in value.items()})
+    return str(value)
+
+
+def _jsonable(value):
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.hex()
+    if isinstance(value, (datetime.datetime, datetime.date)):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, ldap3.utils.ciDict.CaseInsensitiveDict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    return str(value)
+
+
+def export_results(results, fmt, path, attributes=None):
+    """
+    Export a results dict ({dn: {attribute: value, ...}, ...}) to `path`
+    in one of EXPORT_FORMATS. If `attributes` is empty or contains "*",
+    the column list is the sorted union of every attribute seen in the
+    results. Returns the absolute path of the written file.
+    """
+    fmt = fmt.lower()
+    if fmt not in EXPORT_FORMATS:
+        raise ValueError("Unsupported export format: %s (use one of %s)" % (fmt, ", ".join(EXPORT_FORMATS)))
+
+    path_to_file = _resolve_export_path(path)
+
+    if fmt == "json":
+        payload = {dn: _jsonable(results[dn]) for dn in results.keys()}
+        with open(path_to_file, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+        return path_to_file
+
+    cols = _collect_attributes(results, attributes)
+    header_fields = ["distinguishedName"] + cols
+
+    if fmt == "csv":
+        with open(path_to_file, "w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(header_fields)
+            for dn in results.keys():
+                row = [dn]
+                for attr in cols:
+                    if attr in results[dn].keys():
+                        row.append(_stringify_cell(results[dn][attr]))
+                    else:
+                        row.append("")
+                writer.writerow(row)
+        return path_to_file
+
+    # fmt == "xlsx"
+    workbook_options = {
+        "constant_memory": True,
+        "in_memory": True,
+        "strings_to_formulas": False,
+        "remove_timezone": True,
+    }
+    workbook = xlsxwriter.Workbook(filename=path_to_file, options=workbook_options)
+    worksheet = workbook.add_worksheet()
+    header_format = workbook.add_format({"bold": 1})
+    for k in range(len(header_fields)):
+        worksheet.set_column(k, k + 1, len(header_fields[k]) + 3)
+    worksheet.set_row(0, 20, header_format)
+    worksheet.write_row(0, 0, header_fields)
+    row_id = 1
+    for dn in results.keys():
+        row = [dn]
+        for attr in cols:
+            if attr in results[dn].keys():
+                row.append(_stringify_cell(results[dn][attr]))
+            else:
+                row.append("")
+        worksheet.write_row(row_id, 0, row)
+        row_id += 1
+    last_row = max(row_id - 1, 1)
+    worksheet.autofilter(0, 0, last_row, len(header_fields) - 1)
+    workbook.close()
+    return path_to_file
 
 
 ### LDAPConsole
@@ -711,6 +843,23 @@ if __name__ == "__main__":
                     # Exit the command line
                     elif command == "exit":
                         running = False
+
+                    # Export the results of the last query
+                    elif command == "export":
+                        if len(arguments) < 2:
+                            print("\x1b[91m[!] Usage: export <%s> <path>\x1b[0m" % "|".join(EXPORT_FORMATS))
+                        elif len(last1_query_results) == 0:
+                            print("\x1b[91m[!] No query results to export. Run a query first.\x1b[0m")
+                        else:
+                            fmt = arguments[0].lower()
+                            out_path = " ".join(arguments[1:])
+                            try:
+                                written_to = export_results(last1_query_results, fmt, out_path)
+                                print("[+] Exported %d results to %s" % (len(last1_query_results), written_to))
+                            except ValueError as e:
+                                print("\x1b[91m[!] %s\x1b[0m" % str(e))
+                            except OSError as e:
+                                print("\x1b[91m[!] Could not write to %s: %s\x1b[0m" % (out_path, str(e)))
 
                     # Display help
                     elif command == "help":


### PR DESCRIPTION
### Linked Issue
Closes #15

### Motivation
The issue asks for \`export xlsx Poda.xlsx\` syntax in the interactive console. Today, exporting requires leaving the console and re-running \`ldapconsole.py -q ... -x file.xlsx\` in non-interactive mode, which also re-executes the search. Adding an \`export\` command lets the user save the last query's results without rerunning it, and extends the formats to JSON and CSV which the issue title also enumerates.

### What Changed
- New module-level helper \`export_results(results, fmt, path, attributes=None)\` that serializes the common \`{dn: {attr: value, ...}, ...}\` shape to JSON, CSV, or XLSX.
  - \`_resolve_export_path\` creates the parent directory if needed and returns the concrete file path.
  - \`_collect_attributes\` returns the sorted union of attributes across all result entries when the caller did not supply a concrete list or supplied \`\"*\"\`.
  - \`_stringify_cell\` and \`_jsonable\` normalize \`bytes\`, \`list\`, \`ldap3.utils.ciDict.CaseInsensitiveDict\`, and \`datetime\` values into CSV/XLSX-safe strings and JSON-native structures respectively.
  - \`EXPORT_FORMATS\` constant enumerates the supported formats.
- New interactive command \`export <json|csv|xlsx> <path>\` in the REPL. It reports an error if no prior query was run, validates the format, and reports the written path on success.
- \`CommandCompleter\` registers the \`export\` command with its three subcommands so tab completion works.
- Added \`import csv\`, \`import json\`, \`import datetime\` at the top of the file.

### Design Notes
The existing \`--xlsx\` code path in non-interactive mode is left as-is for this PR to keep the diff focused on the interactive command requested by the issue. The new helper is intentionally generic enough that a follow-up could DRY up the \`--xlsx\` path by calling \`export_results\` from there too. JSON export preserves the full attribute payload (no column projection) because JSON consumers typically want the complete record; CSV/XLSX require a column header so they fall back to the sorted-union strategy.

### Acceptance Criteria Check
- [x] \`export xlsx <path>\` is accepted in the interactive console — wired in the REPL loop and registered in \`CommandCompleter\`.
- [x] JSON format is supported — \`export json <path>\` dumps the last query results via \`json.dump\`.
- [x] CSV format is supported — \`export csv <path>\` writes a UTF-8 CSV via the stdlib \`csv\` module.
- [x] Export targets the results of the last query, not a re-execution — uses the existing \`last1_query_results\` variable.

### How Verified
Runtime: loaded the module with the \`sectools\` import stubbed out and called \`export_results\` with a results dict containing \`str\`, \`bytes\`, and mixed-attribute entries.
- JSON: inspected the pretty-printed output; \`bytes\` values were decoded and nested lists preserved.
- CSV: inspected the header (\`distinguishedName,description,sAMAccountName\`) and rows with mixed bytes/str.
- XLSX: 5547-byte workbook written, 5415 bytes for an empty result set (no IndexError on empty input).
- Unsupported format: \`export_results(..., 'pdf', ...)\` raises \`ValueError: Unsupported export format: pdf (use one of json, csv, xlsx)\` which the REPL catches and prints.

### Test Coverage
None — the repository has no test suite. The export logic is exercised only through the manual smoke test described above.

### Scope of Change
- **Files changed:** \`ldapconsole.py\`
- **Submodule pointer updated:** no
- **Public API changes:** additive (new \`export_results\` function, new \`EXPORT_FORMATS\` tuple, new interactive command)
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
New code paths only; no existing behavior changes. Safe to merge without staged rollout.

### Notes
Follow-up opportunity (not in this PR): route the non-interactive \`--xlsx\` path through \`export_results\` to remove the duplicated workbook-writing code.