### PR TITLE
Fix diff command old/new null-check swap (#22)

### DIFF
--- a/ldapconsole.py
+++ b/ldapconsole.py
@@ -699,14 +699,14 @@ if __name__ == "__main__":
                                 for _ad in attrs_diff:
                                     path, vl1, vl2 = _ad
                                     print("    " + "──>".join(["\"\x1b[93m%s\x1b[0m\"" % attr for attr in path]) + ":")
-                                    if vl1 is not None:
+                                    if vl2 is not None:
                                         print("    " + "  > " + "Old value:", vl2)
                                     else:
-                                        print("    " + "  > " + "Old value: None (attribute was not present in the last reponse)")
-                                    if vl2 is not None:
+                                        print("    " + "  > " + "Old value: None (attribute was not present in the last response)")
+                                    if vl1 is not None:
                                         print("    " + "  > " + "New value:", vl1)
                                     else:
-                                        print("    " + "  > " + "New value: None (attribute is not present in the reponse)")
+                                        print("    " + "  > " + "New value: None (attribute is not present in the response)")
 
                     # Exit the command line
                     elif command == "exit":


### PR DESCRIPTION
### Linked Issue
Closes #22

### Root Cause
In the \`diff\` interactive command, the per-attribute print block assigns \`vl2\` from \`last2_query_results\` (older) and \`vl1\` from \`last1_query_results\` (newer), and prints \`vl2\` as the \"Old value\" and \`vl1\` as the \"New value\". However the \`if ... is not None\` guards check the opposite variable: the \"Old value\" branch checked \`vl1\`, and the \"New value\" branch checked \`vl2\`. When exactly one side was \`None\` (attribute added or removed between the two queries), the user saw the removal/addition mirrored — the \"Old value: None\" label appeared when the *new* value was missing.

### Fix Description
Swap the two null-check variables so the \`if\` guarding each label tests the variable actually being printed. Also correct the \"reponse\" typo in the same two strings since the lines were already being edited.

### How Verified
Static analysis against the patched lines:
- \"Old value\" branch now checks \`vl2\` (the old side) — if it is \`None\`, the human-readable fallback prints; otherwise \`vl2\` is printed.
- \"New value\" branch now checks \`vl1\` (the new side) — same pattern.

### Test Coverage
None — the repository has no test suite and the affected code is an interactive printing path with no return value to assert on. The diff logic above has no branches besides the two conditions being fixed.

### Scope of Change
- **Files changed:** \`ldapconsole.py\`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none