### PR TITLE
Fix searchscope command not propagating to queries (#24)

### DIFF
--- a/ldapconsole.py
+++ b/ldapconsole.py
@@ -749,7 +749,7 @@ if __name__ == "__main__":
                                 _attrs = ["*"]
 
                             last2_query_results = last1_query_results
-                            last1_query_results = ls.query(base_dn=search_base, query=_query, attributes=_attrs)
+                            last1_query_results = ls.query(base_dn=search_base, query=_query, attributes=_attrs, search_scope=search_scope)
 
                             for dn in sorted(list(last1_query_results.keys())):
                                 ls.print_colored_result(dn=dn, data=last1_query_results[dn])


### PR DESCRIPTION
### Linked Issue
Closes #24

### Root Cause
The interactive \`searchscope\` command writes to a local \`search_scope\` variable, but the \`query\` command's call site invokes \`ls.query(base_dn=..., query=..., attributes=...)\` without forwarding \`search_scope\`. \`LDAPSearcher.query\` defaults \`search_scope\` to \`ldap3.SUBTREE\`, so every user search ran with subtree scope regardless of what the user configured.

### Fix Description
Forward \`search_scope=search_scope\` into the \`ls.query(...)\` call in the \`query\` branch. The \`rootdse\` branch already passes \`search_scope=ldap3.BASE\` explicitly, so it does not need to change.

### How Verified
Static: before the change, \`searchscope BASE\` followed by \`query (objectClass=*)\` would still return a subtree search. After the change, \`ls.query\` receives the user-selected \`search_scope\` value.

### Test Coverage
None — the repository has no test suite and the change is a single keyword argument forwarded at one call site.

### Scope of Change
- **Files changed:** \`ldapconsole.py\`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none