### PR TITLE
Fix all_kerberoastables preset query (#26)

### DIFF
--- a/ldapconsole.py
+++ b/ldapconsole.py
@@ -378,6 +378,11 @@ class PresetQueries(object):
             "description": "Get the list of all organizationalUnits.",
             "filter": "(objectClass=organizationalUnit)",
             "attributes": ["distinguishedName"]
+        },
+        "all_kerberoastables": {
+            "description": "Get all user accounts with a servicePrincipalName (kerberoastable).",
+            "filter": "(&(objectClass=user)(servicePrincipalName=*)(!(objectClass=computer))(!(cn=krbtgt))(!(userAccountControl:1.2.840.113556.1.4.803:=2)))",
+            "attributes": ["sAMAccountName", "servicePrincipalName"]
         }
     }
     
@@ -401,38 +406,52 @@ class PresetQueries(object):
 
             elif command == "all_descriptions":
                 self.get_all_descriptions()
-            
+
             elif command == "all_kerberoastables":
-                _query = "(&(objectClass=user)(servicePrincipalName=*)(!(objectClass=computer))(!(cn=krbtgt))(!(userAccountControl:1.2.840.113556.1.4.803:=2)))"
-                _attrs = ["sAMAccountName", "servicePrincipalName"]
-                last2_query_results = last1_query_results
-                last1_query_results = self.ldapSearcher.query(_query, attributes=_attrs, quiet=True)
-                if len(last1_query_results.keys()) != 0:
-                    for key in last1_query_results.keys():
-                        user = last1_query_results[key]
-                        _sAMAccountName = user["sAMAccountName"][0].decode("UTF-8")
-                        for spn in user["servicePrincipalName"]:
-                            print(" | \x1b[93m%-25s\x1b[0m : \x1b[96m%-30s\x1b[0m" % (_sAMAccountName, spn.decode("UTF-8")))
-                else:
+                self.get_all_kerberoastables()
+
+            else:
+                results = self.ldapSearcher.query_all_naming_contexts(
+                    query=self.preset_queries[command]["filter"],
+                    attributes=self.preset_queries[command]["attributes"],
+                )
+                if len(results) == 0:
                     print("\x1b[91mNo results.\x1b[0m")
-                    
-            elif command == "all_descriptions":
-                _query = "(&(objectCategory=person)(objectClass=user)(description=*))"
-                _attrs = ["description", "sAMAccountName"]
-                last2_query_results = last1_query_results
-                last1_query_results = self.ldapSearcher.query(_query, attributes=_attrs, quiet=True)
-                if len(last1_query_results.keys()) != 0:
-                    for key in last1_query_results.keys():
-                        user = last1_query_results[key]
-                        _sAMAccountName = user["sAMAccountName"][0].decode("UTF-8")
-                        _description = user["description"][0].decode("UTF-8")
-                        print(" | \x1b[93m%-25s\x1b[0m : \x1b[96m%s\x1b[0m" % (_sAMAccountName, _description))
                 else:
-                    print("\x1b[91mNo results.\x1b[0m")
-        
+                    for distinguishedName in results.keys():
+                        print(" | \x1b[93m%s\x1b[0m" % distinguishedName)
+
         else:
             print("[!] Unknown preset query \"%s\". Here is a list of the available preset queries:" % command)
             self.print_help()
+
+    def get_all_kerberoastables(self):
+        """
+        Retrieve all user accounts that carry a servicePrincipalName and are
+        therefore kerberoastable (excluding computer accounts, krbtgt, and
+        disabled accounts). Prints each match as sAMAccountName / SPN pairs.
+        """
+        results = self.ldapSearcher.query_all_naming_contexts(
+            query=self.preset_queries["all_kerberoastables"]["filter"],
+            attributes=self.preset_queries["all_kerberoastables"]["attributes"],
+        )
+        if len(results) == 0:
+            print("\x1b[91mNo results.\x1b[0m")
+            return
+        for distinguishedName in results.keys():
+            entry = results[distinguishedName]
+            sam = entry.get("sAMAccountName")
+            if isinstance(sam, list):
+                sam = sam[0] if sam else ""
+            if isinstance(sam, bytes):
+                sam = sam.decode("utf-8", errors="replace")
+            spns = entry.get("servicePrincipalName") or []
+            if not isinstance(spns, list):
+                spns = [spns]
+            for spn in spns:
+                if isinstance(spn, bytes):
+                    spn = spn.decode("utf-8", errors="replace")
+                print(" | \x1b[93m%-25s\x1b[0m : \x1b[96m%-30s\x1b[0m" % (sam, spn))
 
     def get_all_users(self, attributes=["objectSid", "sAMAccountName"]):
         """


### PR DESCRIPTION
### Linked Issue
Closes #26

### Root Cause
\`all_kerberoastables\` appeared in \`CommandCompleter.options['presetquery']['subcommands']\` but was never registered in \`PresetQueries.preset_queries\`. Since \`PresetQueries.perform\` gates its dispatch on \`if command in self.preset_queries.keys()\`, the preset always fell through to the \"Unknown preset query\" branch. Separately, the orphaned inline handler inside \`perform\` referenced an \`UnboundLocalError\`-prone \`last1_query_results\` name and called \`LDAPSearcher.query\` with a missing \`base_dn\` and a non-existent \`quiet\` kwarg — it was dead code that would have crashed if reached.

### Fix Description
- Register \`all_kerberoastables\` in \`PresetQueries.preset_queries\` with the kerberoastable filter and \`[sAMAccountName, servicePrincipalName]\` attributes.
- Add \`PresetQueries.get_all_kerberoastables()\` that runs the filter via \`ldapSearcher.query_all_naming_contexts\` and prints sAMAccountName / SPN pairs. Handles both \`str\` and \`bytes\` attribute values returned by ldap3.
- Route the \`perform\` dispatch to the new method and replace the broken orphaned block with a generic fallback that runs \`query_all_naming_contexts\` for any preset that only needs filter + attributes printing. This removes the \`UnboundLocalError\` / \`TypeError\` call-site.

### How Verified
Runtime: with a stubbed \`LDAPSearcher\` that returns two kerberoastable users (one with \`str\` values, one with \`bytes\` values, and multiple SPNs on one account):

\`\`\`
=== dispatch: all_kerberoastables ===
FakeSearcher called: query='(&(objectClass=user)(servicePrincipalName=*)(!(objectClass=computer))(!(cn=krbtgt))(!(userAccountControl:1.2.840.113556.1.4.803:=2)))' attrs=['sAMAccountName', 'servicePrincipalName']
 | svc_sql                   : MSSQLSvc/sql.lab.local:1433
 | svc_sql                   : MSSQLSvc/sql.lab.local
 | svc_web                   : HTTP/web.lab.local
\`\`\`

Empty-result path printed \`No results.\` as expected.

### Test Coverage
None — the repository has no test suite. Verified manually against a stubbed searcher with mixed \`str\`/\`bytes\` attribute values and multiple SPNs.

### Scope of Change
- **Files changed:** \`ldapconsole.py\`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The generic fallback in \`perform\` is reached only for presets that were previously silently ignored by the if/elif chain (\`all_groups\`, \`all_computers\`, \`all_organizational_units\` — all of which were registered in the dict but had no matching \`elif\`), which is a side-effect fix; prior behavior for those presets was \"drop through to else → Unknown preset query\", which was clearly a bug.

### Notes
A follow-up (tracked separately) will sync the \`CommandCompleter.options['presetquery']['subcommands']\` list so it also exposes \`all_computers\` and \`all_organizational_units\` via tab completion. That is a completer-only change and does not belong in this PR.