### PR TITLE
Fix get_all_descriptions format_sid misuse (#28)

### DIFF
--- a/ldapconsole.py
+++ b/ldapconsole.py
@@ -482,9 +482,18 @@ class PresetQueries(object):
 
         if len(results.keys()) != 0:
             for distinguishedName in results.keys():
-                _sAMAccountName = results[distinguishedName]["sAMAccountName"]
-                _description = format_sid(results[distinguishedName]["description"][0])
-                print(" | \x1b[93m%-25s\x1b[0m : \x1b[96m%s\x1b[0m" % (_sAMAccountName, _description))
+                entry = results[distinguishedName]
+                sam = entry.get("sAMAccountName")
+                if isinstance(sam, list):
+                    sam = sam[0] if sam else ""
+                if isinstance(sam, bytes):
+                    sam = sam.decode("utf-8", errors="replace")
+                description = entry.get("description")
+                if isinstance(description, list):
+                    description = description[0] if description else ""
+                if isinstance(description, bytes):
+                    description = description.decode("utf-8", errors="replace")
+                print(" | \x1b[93m%-25s\x1b[0m : \x1b[96m%s\x1b[0m" % (sam, description))
         else:
             print("\x1b[91mNo results.\x1b[0m")
 


### PR DESCRIPTION
### Linked Issue
Closes #28

### Root Cause
\`get_all_descriptions\` was copy-pasted from \`get_all_users\` and the SID-formatter call was never swapped out for a plain attribute read. The \`description\` attribute is a string (or list of strings/bytes) — running it through \`ldap3.protocol.formatters.formatters.format_sid\` treats those bytes as a binary SID and either raises or prints garbage. On the same lines, \`sAMAccountName\` was printed as the raw list container (e.g. \`[\"alice\"]\`) instead of its first value.

### Fix Description
Normalise both attributes before printing: if the value is a list take its first element (or \`\"\"\` if empty), then decode \`bytes\` to UTF-8 (with replacement on decode errors). Drop the \`format_sid\` call entirely since \`description\` is a human-readable string.

### How Verified
Runtime, against a stubbed searcher returning three rows — one with \`str\` values, one with \`bytes\` values, one with an empty \`description\` list:

\`\`\`
 | alice                     : Wonderland guide
 | bob                       : plumber
 | carol                     :
\`\`\`

Before the patch, the same input raised \`TypeError\` on the first row (passing \`\"Wonderland guide\"\` to \`format_sid\`) and would print the sAMAccountName field as \`['alice']\`.

### Test Coverage
None — the repository has no test suite; verified via a local smoke script against a stubbed searcher.

### Scope of Change
- **Files changed:** \`ldapconsole.py\`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none