### PR TITLE
Fix IndexError on presetquery/searchscope with empty arguments (#30)

### DIFF
--- a/ldapconsole.py
+++ b/ldapconsole.py
@@ -723,7 +723,11 @@ if __name__ == "__main__":
                     # Perform a presetquery
                     elif command == "presetquery":
                         pq = PresetQueries(ldapSearcher=ls)
-                        pq.perform(command=arguments[0], arguments=arguments[1:])
+                        if len(arguments) == 0:
+                            print("[!] Usage: presetquery <name>. Available preset queries:")
+                            pq.print_help()
+                        else:
+                            pq.perform(command=arguments[0], arguments=arguments[1:])
                     
                     # Perform an LDAP query
                     elif command == "query":
@@ -800,12 +804,18 @@ if __name__ == "__main__":
 
                     # Set the search scope
                     elif command == "searchscope":
-                        if arguments[0].lower() == "base":
-                            search_scope = ldap3.BASE
-                        elif arguments[0].lower() == "level":
-                            search_scope = ldap3.LEVEL
-                        elif arguments[0].lower() == "subtree":
-                            search_scope = ldap3.SUBTREE
+                        if len(arguments) == 0:
+                            print("[!] Usage: searchscope <base|level|subtree>")
+                        else:
+                            scope_arg = arguments[0].lower()
+                            if scope_arg == "base":
+                                search_scope = ldap3.BASE
+                            elif scope_arg == "level":
+                                search_scope = ldap3.LEVEL
+                            elif scope_arg == "subtree":
+                                search_scope = ldap3.SUBTREE
+                            else:
+                                print("[!] Unknown scope %r. Accepted values: base, level, subtree" % arguments[0])
 
                     # Fallback to unknown command
                     else:


### PR DESCRIPTION
### Linked Issue
Closes #30

### Root Cause
Both \`presetquery\` and \`searchscope\` indexed \`arguments[0]\` unconditionally. When the user hit Enter with no following token, \`arguments\` was \`[]\` and \`arguments[0]\` raised \`IndexError\`. The interactive loop's outer \`except Exception\` caught the error and unwound out of the REPL, ending the session.

### Fix Description
- \`presetquery\`: if \`arguments\` is empty, print a usage hint and the preset-query help (\`PresetQueries.print_help()\`) rather than dispatching.
- \`searchscope\`: if \`arguments\` is empty, print a usage hint; otherwise match the lower-cased value against the three accepted scopes and print an \"Unknown scope\" message for any other input. This also tightens the previous behavior where an unrecognised scope silently left \`search_scope\` unchanged.

### How Verified
Static: both branches now perform a \`len(arguments) == 0\` check before any \`arguments[0]\` access, so the \`IndexError\` path is unreachable. The subsequent \`arguments[0].lower()\` in \`searchscope\` is only reached inside the \`else\` branch.

### Test Coverage
None — the repository has no test suite and the change is purely defensive input handling in an interactive REPL.

### Scope of Change
- **Files changed:** \`ldapconsole.py\`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** the \`searchscope\` command now prints a diagnostic when the user supplies a scope other than \`base\`/\`level\`/\`subtree\`; previously that case was silently ignored. This is a strict improvement over silently discarding user input.