### PR TITLE
Fix presetquery tab-completion list drift (#32)

### DIFF
--- a/ldapconsole.py
+++ b/ldapconsole.py
@@ -42,8 +42,8 @@ class CommandCompleter(object):
                 "subcommands": []
             },
             "presetquery": {
-                "description": ["Use a builtin preset query."], 
-                "subcommands": ["all_descriptions", "all_groups", "all_kerberoastables", "all_users"]
+                "description": ["Use a builtin preset query."],
+                "subcommands": ["all_computers", "all_descriptions", "all_groups", "all_organizational_units", "all_users"]
             },
             "query": {
                 "description": [


### PR DESCRIPTION
### Linked Issue
Closes #32

### Root Cause
\`CommandCompleter.options[\"presetquery\"][\"subcommands\"]\` is a hand-maintained list that drifted from the actual presets registered in \`PresetQueries.preset_queries\`. It advertised \`all_kerberoastables\` (not registered in \`preset_queries\` on master) and omitted \`all_computers\` and \`all_organizational_units\` (both present in \`preset_queries\`). Users pressing Tab at the \`presetquery \` prompt could not discover the two omitted presets.

### Fix Description
Replace the hand-maintained list with the five presets actually registered in \`PresetQueries.preset_queries\` on master: \`all_computers\`, \`all_descriptions\`, \`all_groups\`, \`all_organizational_units\`, \`all_users\`. \`all_kerberoastables\` is intentionally omitted here — it is not registered in \`preset_queries\` on master (see #26) and will be re-added to the completer as part of the kerberoastables dispatch fix (#27) once that lands.

### How Verified
Static: after the change, every entry in the completer's \`subcommands\` list maps to a key in \`PresetQueries.preset_queries\`, and every key in \`preset_queries\` appears in the list. The sibling \`description\` line that prints \"Available preset queries are: ...\" is built from this list at \`__init__\` time, so it now also reflects the correct set.

### Test Coverage
None — the repository has no test suite and the change is a one-line data-only edit.

### Scope of Change
- **Files changed:** \`ldapconsole.py\`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none